### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Shu Pu (Sellers Guru): Enable sellers to update stock, add/remove products, and 
 
 Shanruo Xu (Social Guru): Implement a comprehensive feedback system that allows users to submit, edit, and view reviews for products and sellers.
 
-Respiratory link: https://github.com/Duckycoders/PinXiXi
+Repository link: https://github.com/Duckycoders/PinXiXi
 
 Video for MS3 already pushed to Github,link:https://github.com/Duckycoders/PinXiXi/blob/main/Pin%20Xixi%20ms3.mp4
 


### PR DESCRIPTION
## Summary
- fix the phrase "Respiratory link" to "Repository link" in README

## Testing
- `grep -n "Repository link" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_68468eb9067c832792f0b15e2110af28