### PR TITLE
Fix category query

### DIFF
--- a/src/main/java/com/example/mini_amazon/mapper/CategoryMapper.java
+++ b/src/main/java/com/example/mini_amazon/mapper/CategoryMapper.java
@@ -11,7 +11,9 @@ import java.util.List;
 
 @Mapper
 public interface CategoryMapper {
-    @Select("SELECT * FROM Categories")
+    // Table name should be lower case 'categories'
+    // Using capital 'Categories' will fail on case-sensitive databases
+    @Select("SELECT * FROM categories")
     List<Category> findAll();
 }
 


### PR DESCRIPTION
## Summary
- fix `CategoryMapper` query to match lowercase table name

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465b9b5a808327ae46408c76bebd36